### PR TITLE
Cleanup tests

### DIFF
--- a/tests/tox_tests/test_med_00_client.py
+++ b/tests/tox_tests/test_med_00_client.py
@@ -6,7 +6,7 @@ from tests.configuration.fixtures import get_sample_file_path, sftp_client
 
 
 @patch('tempfile.TemporaryDirectory.__enter__', return_value=get_sample_file_path(''))
-def test_get_file_handle(sftp_client):
+def test_get_file_handle(patch_temp, sftp_client):
     """
         Patch the temp file location and the sftp conn. Confirms no errors reading the file after sftp get 
     """

--- a/tests/tox_tests/test_med_00_client.py
+++ b/tests/tox_tests/test_med_00_client.py
@@ -6,7 +6,7 @@ from tests.configuration.fixtures import get_sample_file_path, sftp_client
 
 
 @patch('tempfile.TemporaryDirectory.__enter__', return_value=get_sample_file_path(''))
-def test_get_file_handle(patch_temp, sftp_client):
+def test_get_file_handle(sftp_client):
     """
         Patch the temp file location and the sftp conn. Confirms no errors reading the file after sftp get 
     """

--- a/tests/tox_tests/test_med_00_discover.py
+++ b/tests/tox_tests/test_med_00_discover.py
@@ -34,14 +34,6 @@ expected_schema = {
             }
         }
 
-# @patch('tap_sftp.client', return_value=1)
-# @patch('tap_sftp.tap.sync_stream')
-# def test_sync(patch_sync_stream, mock_client, sftp_client):
-#     catalog = get_catalog()
-    
-#     mock_client.return_value = sftp_client
-
-
 @patch('tap_sftp.client')
 @patch('tap_sftp.client.SFTPConnection.get_files_by_prefix')
 @patch('tap_sftp.client.SFTPConnection.get_file_handle')


### PR DESCRIPTION
Removing the commented-out test in `test_med_00_discover.py` because it is located in `test_med_00_tap_sftp.py` file. Also removing an unneeded parameter in another test.