### PR TITLE
Metadata columns

### DIFF
--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -7,7 +7,7 @@ from tap_sftp import decrypt
 from tap_sftp.singer_encodings import compression
 
 SDC_EXTRA_COLUMN = "_sdc_extra"
-
+SDC_META_COLUMNS = ['_sdc_source_file', '_sdc_source_lineno']
 
 def get_row_iterators(iterable, options={}, infer_compression=False):
     """Accepts an interable, options and a flag to infer compression and yields
@@ -31,7 +31,7 @@ def get_row_iterator(iterable, options=None):
         delimiter=options.get('delimiter', ',')
     )
 
-    headers = set(reader.fieldnames)
+    headers = set(reader.fieldnames + SDC_META_COLUMNS) 
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -9,6 +9,7 @@ from tap_sftp.singer_encodings import compression
 SDC_EXTRA_COLUMN = "_sdc_extra"
 SDC_META_COLUMNS = ['_sdc_source_file', '_sdc_source_lineno']
 
+
 def get_row_iterators(iterable, options={}, infer_compression=False):
     """Accepts an interable, options and a flag to infer compression and yields
     csv.DictReader objects which can be used to yield CSV rows."""
@@ -31,7 +32,7 @@ def get_row_iterator(iterable, options=None):
         delimiter=options.get('delimiter', ',')
     )
 
-    headers = set(reader.fieldnames + SDC_META_COLUMNS) 
+    headers = set(reader.fieldnames + SDC_META_COLUMNS)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tests/configuration/fixtures.py
+++ b/tests/configuration/fixtures.py
@@ -65,3 +65,12 @@ def get_table_spec():
         'key_properties': [],
         'delimiter': ','
     }
+
+def get_table_spec_meta_keys():
+    return {
+        'table_name': 'fake_file',
+        'search_prefix': '/Export',
+        'search_pattern': 'fake_file*',
+        'key_properties': ['_sdc_source_file', '_sdc_source_lineno'],
+        'delimiter': ','
+    }


### PR DESCRIPTION
A minimal implementation for the tap to accept the metadata columns `_sdc_source_file` and `_sdc_source_lineno` as unique keys in the `key_properties` config.

This enables pipelines that use file names as part of the unique key, and makes it possible to set up pipelines without knowing the unique key of the data and still, in most real-world use cases [citation needded], get it right.

Includes a simple test for this use case.

As a sidenote, because of the header being line one, no line number 1 will turn up in the target data.