### PR TITLE
Sanitize header

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ Create a `config.json` file with connection details to snowflake.
    - `table_name`: The name that should be given to the table (stream)
    - `search_prefix`: Folder where the files are located
    - `search_pattern`: Regex pattern to match the file names
-   - `delimiter`: CSV file delimiter,
+   - `delimiter`: CSV file delimiter
 
    The following table configuration fields are optional:
    - `key_properties`: Array containing the unique keys of the table. Defaults to `['_sdc_source_file', '_sdc_source_lineno']`, representing the file name and line number. Specify an emtpy array (`[]`) to load all new files without a replication key
    - `encoding`: File encoding, defaults to `utf-8`
-   - `sanitize_header`: Boolean, specifies wether to clean up header names so that they are more likely to be accepted by a target SQL database.
+   - `sanitize_header`: Boolean, specifies wether to clean up header names so that they are more likely to be accepted by a target SQL database
 
 ## Discovery mode:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ pip install .
 
 ## Configuration:
 
-1. Create a `config.json` file with connection details to snowflake.
+Create a `config.json` file with connection details to snowflake.
 
    ```json
    {
@@ -41,7 +41,8 @@ $ pip install .
                 "search_pattern": "MyExportData.*\\.zip.gpg$",
                 "key_properties": [],
                 "delimiter": ",",
-                "encoding": "utf-8"
+                "encoding": "utf-8",
+                "sanitize_header": false
             }
         ],
         "start_date":"2021-01-28",
@@ -55,7 +56,25 @@ $ pip install .
    ```
    If using the decryption feature you must pass the configs shown above, including the AWS SSM parameter name for where the decryption private key is stored. In order to retrieve this parameter the runtime environment must have access to SSM through IAM environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN).
 
-   The private_key_file is optional.
+   The following fields are required for the connection configuration:
+   - `host`: Hostname or IP of the SFTP server
+   - `username`: Username for the SFTP server
+   - `port`: Port number for the SFTP server
+   - `tables`: An array of tables to load. See table configuration below
+   - `start_date`: Earliest file date to synchronize
+   - either `password` or `private_key_file`: Authentication to the SFTP Server
+
+
+   The following table configuration fields are required:
+   - `table_name`: The name that should be given to the table (stream)
+   - `search_prefix`: Folder where the files are located
+   - `search_pattern`: Regex pattern to match the file names
+   - `delimiter`: CSV file delimiter,
+
+   The following table configuration fields are optional:
+   - `key_properties`: Array containing the unique keys of the table. Defaults to `['_sdc_source_file', '_sdc_source_lineno']`, representing the file name and line number. Specify an emtpy array (`[]`) to load all new files without a replication key
+   - `encoding`: File encoding, defaults to `utf-8`
+   - `sanitize_header`: Boolean, specifies wether to clean up header names so that they are more likely to be accepted by a target SQL database.
 
 ## Discovery mode:
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ Create a `config.json` file with connection details to snowflake.
    - `table_name`: The name that should be given to the table (stream)
    - `search_prefix`: Folder where the files are located
    - `search_pattern`: Regex pattern to match the file names
-   - `delimiter`: CSV file delimiter
+   - `delimiter`: A one-character string delimiter used to separate fields. Default, is `,`.
 
    The following table configuration fields are optional:
    - `key_properties`: Array containing the unique keys of the table. Defaults to `['_sdc_source_file', '_sdc_source_lineno']`, representing the file name and line number. Specify an emtpy array (`[]`) to load all new files without a replication key
    - `encoding`: File encoding, defaults to `utf-8`
-   - `sanitize_header`: Boolean, specifies wether to clean up header names so that they are more likely to be accepted by a target SQL database
+   - `sanitize_header`: Boolean, specifies whether to clean up header names so that they are more likely to be accepted by a target SQL database
 
 ## Discovery mode:
 

--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -17,8 +17,7 @@ def discover_streams(config):
         LOGGER.info('Sampling records to determine table JSON schema "%s".', table_spec['table_name'])
         schema = json_schema.get_schema_for_table(conn, table_spec, config)
         stream_md = metadata.get_standard_metadata(schema,
-                                                   key_properties=table_spec.get('key_properties', 
-                                                   ['_sdc_source_file', '_sdc_source_lineno']),
+                                                   key_properties=table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),  # noqa
                                                    replication_method='INCREMENTAL')
         streams.append(
             {

--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -17,7 +17,8 @@ def discover_streams(config):
         LOGGER.info('Sampling records to determine table JSON schema "%s".', table_spec['table_name'])
         schema = json_schema.get_schema_for_table(conn, table_spec, config)
         stream_md = metadata.get_standard_metadata(schema,
-                                                   key_properties=table_spec.get('key_properties'),
+                                                   key_properties=table_spec.get('key_properties', 
+                                                   ['_sdc_source_file', '_sdc_source_lineno']),
                                                    replication_method='INCREMENTAL')
         streams.append(
             {

--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -17,7 +17,7 @@ def discover_streams(config):
         LOGGER.info('Sampling records to determine table JSON schema "%s".', table_spec['table_name'])
         schema = json_schema.get_schema_for_table(conn, table_spec, config)
         stream_md = metadata.get_standard_metadata(schema,
-                                                   key_properties=table_spec.get('key_properties'),
+                                                   key_properties=table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
                                                    replication_method='INCREMENTAL')
         streams.append(
             {

--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -17,7 +17,7 @@ def discover_streams(config):
         LOGGER.info('Sampling records to determine table JSON schema "%s".', table_spec['table_name'])
         schema = json_schema.get_schema_for_table(conn, table_spec, config)
         stream_md = metadata.get_standard_metadata(schema,
-                                                   key_properties=table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
+                                                   key_properties=table_spec.get('key_properties'),
                                                    replication_method='INCREMENTAL')
         streams.append(
             {

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -42,8 +42,8 @@ def get_row_iterator(iterable, options=None):
     if 'sanitize_headers' in options and options['sanitize_headers']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
-    headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
-    # headers = set(reader.fieldnames)
+    # headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
+    headers = set(reader.fieldnames)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -34,7 +34,7 @@ def get_row_iterator(iterable, options=None):
     # Replace any NULL bytes in the line given to the DictReader
     reader = csv.DictReader(
         io.TextIOWrapper(iterable, encoding=options.get('encoding', 'utf-8')),
-        fieldnames=None,
+        #fieldnames=None,
         restkey=SDC_EXTRA_COLUMN,
         delimiter=options.get('delimiter', ',')
     )

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -39,7 +39,7 @@ def get_row_iterator(iterable, options=None):
         delimiter=options.get('delimiter', ',')
     )
 
-    if 'sanitize_headers' in options and options['sanitize_headers']:
+    if 'sanitize_header' in options and options['sanitize_header']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
     headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -42,8 +42,8 @@ def get_row_iterator(iterable, options=None):
     if 'sanitize_headers' in options and options['sanitize_headers']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
-    # headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
-    headers = set(reader.fieldnames)
+    headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
+    # headers = set(reader.fieldnames)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -2,6 +2,8 @@ import codecs
 import csv
 import io
 import os
+import singer
+import re
 
 from tap_sftp import decrypt
 from tap_sftp.singer_encodings import compression
@@ -18,6 +20,12 @@ def get_row_iterators(iterable, options={}, infer_compression=False):
         yield get_row_iterator(item, options=options)
 
 
+def sanitize_colname(col_name):
+    sanitized = re.sub(r'[^0-9a-zA-Z_]+', '_', col_name)
+    prefixed = re.sub(r'^(\d+)', r'x_\1', sanitized)
+    return prefixed.lower()
+
+
 def get_row_iterator(iterable, options=None):
     """Accepts an interable, options and returns a csv.DictReader object
     which can be used to yield CSV rows."""
@@ -31,7 +39,11 @@ def get_row_iterator(iterable, options=None):
         delimiter=options.get('delimiter', ',')
     )
 
+    if 'sanitize_headers' in options and options['sanitize_headers']:
+        reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames]
+
     headers = set(reader.fieldnames)
+
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -2,7 +2,6 @@ import codecs
 import csv
 import io
 import os
-import singer
 import re
 
 from tap_sftp import decrypt
@@ -40,10 +39,8 @@ def get_row_iterator(iterable, options=None):
         delimiter=options.get('delimiter', ',')
     )
 
-
     if 'sanitize_header' in options and options['sanitize_header']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
-
 
     headers = set(reader.fieldnames + SDC_META_COLUMNS)
 

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -34,7 +34,7 @@ def get_row_iterator(iterable, options=None):
     # Replace any NULL bytes in the line given to the DictReader
     reader = csv.DictReader(
         io.TextIOWrapper(iterable, encoding=options.get('encoding', 'utf-8')),
-        #fieldnames=None,
+        fieldnames=None,
         restkey=SDC_EXTRA_COLUMN,
         delimiter=options.get('delimiter', ',')
     )
@@ -43,7 +43,7 @@ def get_row_iterator(iterable, options=None):
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
     headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
-    # headers = set(reader.fieldnames)
+
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -42,8 +42,8 @@ def get_row_iterator(iterable, options=None):
     if 'sanitize_headers' in options and options['sanitize_headers']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
-    headers = set(reader.fieldnames)
-
+    headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
+    # headers = set(reader.fieldnames)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -40,7 +40,7 @@ def get_row_iterator(iterable, options=None):
     )
 
     if 'sanitize_headers' in options and options['sanitize_headers']:
-        reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames]
+        reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
     headers = set(reader.fieldnames)
 

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -42,7 +42,7 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),
-            'sanitize_headers': table_spec.get('sanitize_headers', False)}
+            'sanitize_header': table_spec.get('sanitize_header', False)}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -38,7 +38,7 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
         file_handle = conn.get_file_handle(f)
 
     # Add file_name to opts and flag infer_compression to support gzipped files
-    opts = {'key_properties': table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
+    opts = {'key_properties': table_spec.get('key_properties'),
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -41,7 +41,8 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
     opts = {'key_properties': table_spec['key_properties'],
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath'],
-            'encoding': table_spec.get('encoding', 'utf-8')}
+            'encoding': table_spec.get('encoding', 'utf-8'),
+            'sanitize_headers': table_spec.get('sanitize_headers', False)}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -38,8 +38,8 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
         file_handle = conn.get_file_handle(f)
 
     # Add file_name to opts and flag infer_compression to support gzipped files
-    opts = {'key_properties': table_spec.get('key_properties'),
-            'delimiter': table_spec['delimiter'],
+    opts = {'key_properties': table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
+            'delimiter': table_spec.get('delimiter', ','),
             'file_name': f['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),
             'sanitize_header': table_spec.get('sanitize_header', False)}

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -38,7 +38,7 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
         file_handle = conn.get_file_handle(f)
 
     # Add file_name to opts and flag infer_compression to support gzipped files
-    opts = {'key_properties': table_spec['key_properties'],
+    opts = {'key_properties': table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -64,7 +64,7 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
             'delimiter': table_spec.get('delimiter', ','),
             'file_name': sftp_file_spec['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),
-            'sanitize_headers': table_spec.get('sanitize_headers', False)}
+            'sanitize_header': table_spec.get('sanitize_header', False)}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -60,7 +60,7 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
         file_handle = sftp_client.get_file_handle(sftp_file_spec)
 
     # Add file_name to opts and flag infer_compression to support gzipped files
-    opts = {'key_properties': table_spec['key_properties'],
+    opts = {'key_properties': table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
             'delimiter': table_spec.get('delimiter', ','),
             'file_name': sftp_file_spec['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -63,7 +63,8 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
     opts = {'key_properties': table_spec['key_properties'],
             'delimiter': table_spec.get('delimiter', ','),
             'file_name': sftp_file_spec['filepath'],
-            'encoding': table_spec.get('encoding', 'utf-8')}
+            'encoding': table_spec.get('encoding', 'utf-8'),
+            'sanitize_headers': table_spec.get('sanitize_headers', False)}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -91,6 +91,5 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
         LOGGER.info(f'Sync Complete - Records Synced: {records_synced}')
 
     stats.add_file_data(table_spec, sftp_file_spec['filepath'], sftp_file_spec['last_modified'], records_synced)
-    # sftp_client.close()
 
     return records_synced

--- a/tap_sftp/tap.py
+++ b/tap_sftp/tap.py
@@ -12,7 +12,7 @@ from tap_sftp.sync import sync_stream
 
 REQUIRED_CONFIG_KEYS = ["username", "port", "host", "tables", "start_date"]
 REQUIRED_DECRYPT_CONFIG_KEYS = ['SSM_key_name', 'gnupghome', 'passphrase']
-REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
+REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["delimiter", "table_name", "search_prefix", "search_pattern"]
 LOGGER = singer.get_logger()
 
 

--- a/tap_sftp/tap.py
+++ b/tap_sftp/tap.py
@@ -12,8 +12,7 @@ from tap_sftp.sync import sync_stream
 
 REQUIRED_CONFIG_KEYS = ["username", "port", "host", "tables", "start_date"]
 REQUIRED_DECRYPT_CONFIG_KEYS = ['SSM_key_name', 'gnupghome', 'passphrase']
-# REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
-REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["delimiter", "table_name", "search_prefix", "search_pattern"]
+REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
 LOGGER = singer.get_logger()
 
 

--- a/tap_sftp/tap.py
+++ b/tap_sftp/tap.py
@@ -12,8 +12,8 @@ from tap_sftp.sync import sync_stream
 
 REQUIRED_CONFIG_KEYS = ["username", "port", "host", "tables", "start_date"]
 REQUIRED_DECRYPT_CONFIG_KEYS = ['SSM_key_name', 'gnupghome', 'passphrase']
-REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
-
+# REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
+REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["delimiter", "table_name", "search_prefix", "search_pattern"]
 LOGGER = singer.get_logger()
 
 

--- a/tests/configuration/unsanitized_file.csv
+++ b/tests/configuration/unsanitized_file.csv
@@ -1,0 +1,2 @@
+id,Col($2)
+data1,data2

--- a/tests/tox_tests/test_med_00_parse_csv.py
+++ b/tests/tox_tests/test_med_00_parse_csv.py
@@ -1,12 +1,12 @@
 from tap_sftp.singer_encodings import csv_handler
 from tests.configuration.fixtures import get_sample_file_path
 
-def test_sanitize_headers():
+def test_sanitize_header():
     """Test the parser."""
     options = {
         'delimiter': ',',
         'key_properties': ['id'],
-        'sanitize_headers': True,
+        'sanitize_header': True,
     }
 
     with open(get_sample_file_path('unsanitized_file.csv'), 'rb') as file:
@@ -22,7 +22,7 @@ def test_no_sanitized_headers():
     options = {
         'delimiter': ',',
         'key_properties': ['id'],
-        'sanitize_headers': False,
+        'sanitize_header': False,
     }
 
     with open(get_sample_file_path('unsanitized_file.csv'), 'rb') as file:

--- a/tests/tox_tests/test_med_00_parse_csv.py
+++ b/tests/tox_tests/test_med_00_parse_csv.py
@@ -1,0 +1,32 @@
+from tap_sftp.singer_encodings import csv_handler
+from tests.configuration.fixtures import get_sample_file_path
+
+def test_sanitize_headers():
+    """Test the parser."""
+    options = {
+        'delimiter': ',',
+        'key_properties': ['id'],
+        'sanitize_headers': True,
+    }
+
+    with open(get_sample_file_path('unsanitized_file.csv'), 'rb') as file:
+        parser = csv_handler.get_row_iterator(file, options=options)
+
+
+
+    assert parser.fieldnames == ['id', 'col_2_']
+
+
+def test_no_sanitized_headers():
+    """Test the parser."""
+    options = {
+        'delimiter': ',',
+        'key_properties': ['id'],
+        'sanitize_headers': False,
+    }
+
+    with open(get_sample_file_path('unsanitized_file.csv'), 'rb') as file:
+
+        parser = csv_handler.get_row_iterator(file, options=options)
+        
+    assert parser.fieldnames == ['id', 'Col($2)']


### PR DESCRIPTION
Closes https://github.com/MeltanoLabs/tap-sftp/issues/4

Added optional "sanitize_header" config option (bool) to clean file header from special characters.

Replaces non `A-z0-9_` characters with underscore (`_`) and prefixes leading numbers with `x_`.